### PR TITLE
WP-46 Fix jest config error

### DIFF
--- a/WatchParty/client/package.json
+++ b/WatchParty/client/package.json
@@ -33,16 +33,10 @@
     "extends": "react-app"
   },
   "jest": {
-    "verbose": true,
     "clearMocks": false,
     "transform": {
       "^.+\\.js?$": "babel-jest"
-    },
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "json"
-    ]
+    }
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This should be an easy merge. It remove the problematic Jest config from the client app's `package.json`. You can try this PR yourself and see that the Jest tests run just fine now.