### PR TITLE
Actions to move subfolders to right test/deploy repositories

### DIFF
--- a/.github/workflows/backend-to-deploy.yml
+++ b/.github/workflows/backend-to-deploy.yml
@@ -1,0 +1,29 @@
+name: Push Backend to Deploy Repo
+on:
+  push:
+    branches: [ master ]
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: Set up remotes to Backend Deploy Repo
+      run: |
+        git remote add deploy https://github.com/watchpartyappmain/watchparty-server-deploy.git
+        git fetch --all
+        git checkout -b deploy-sync deploy/master
+        git config --global user.email "watchpartyappmain@gmail.com"
+        git config --global user.name "watchpartyappmain"
+        git filter-branch --prune-empty --subdirectory-filter WatchParty/backend master
+        git merge -s ours master --allow-unrelated-histories
+        git fetch --unshallow origin
+    - name: Push Backend to Deploy Repo
+      env:
+        INPUT_GITHUB_TOKEN: ${{ secrets.personal_github_token }}
+        REPOSITORY: 'watchpartyappmain/watchparty-server-deploy'
+        INPUT_BRANCH: 'master'
+      run: |
+        remote_repo="https://watchpartymainapp:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+        git push "${remote_repo}" HEAD:${INPUT_BRANCH} --follow-tags --force;

--- a/.github/workflows/backend-to-test.yml
+++ b/.github/workflows/backend-to-test.yml
@@ -1,0 +1,29 @@
+name: Push Backend to Test Repo
+on:
+  push:
+    branches: [ sandbox ]
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: Set up remotes to Backend Test Repo
+      run: |
+        git remote add testing https://github.com/watchpartyappmain/watchparty-server-test.git
+        git fetch --all
+        git checkout -b sandbox-sync testing/master
+        git config --global user.email "watchpartyappmain@gmail.com"
+        git config --global user.name "watchpartyappmain"
+        git filter-branch --prune-empty --subdirectory-filter WatchParty/backend sandbox
+        git merge -s ours sandbox --allow-unrelated-histories
+        git fetch --unshallow origin
+    - name: Push Backend to Test Repo
+      env:
+        INPUT_GITHUB_TOKEN: ${{ secrets.personal_github_token }}
+        REPOSITORY: 'watchpartyappmain/watchparty-server-test'
+        INPUT_BRANCH: 'master'
+      run: |
+        remote_repo="https://watchpartymainapp:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+        git push "${remote_repo}" HEAD:${INPUT_BRANCH} --follow-tags --force;

--- a/.github/workflows/client-to-deploy.yml
+++ b/.github/workflows/client-to-deploy.yml
@@ -1,0 +1,29 @@
+name: Push Client to Deploy Repo
+on:
+  push:
+    branches: [ master ]
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: Set up remotes to Client Deploy Repo
+      run: |
+        git remote add deploy https://github.com/watchpartyappmain/watchparty-frontend-deploy.git
+        git fetch --all
+        git checkout -b deploy-sync deploy/master
+        git config --global user.email "watchpartyappmain@gmail.com"
+        git config --global user.name "watchpartyappmain"
+        git filter-branch --prune-empty --subdirectory-filter WatchParty/client master
+        git merge -s ours master --allow-unrelated-histories
+        git fetch --unshallow origin
+    - name: Push Client to Deploy Repo
+      env:
+        INPUT_GITHUB_TOKEN: ${{ secrets.personal_github_token }}
+        REPOSITORY: 'watchpartyappmain/watchparty-frontend-deploy'
+        INPUT_BRANCH: 'master'
+      run: |
+        remote_repo="https://watchpartymainapp:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+        git push "${remote_repo}" HEAD:${INPUT_BRANCH} --follow-tags --force;

--- a/.github/workflows/client-to-test.yml
+++ b/.github/workflows/client-to-test.yml
@@ -1,0 +1,29 @@
+name: Push Client to Test Repo
+on:
+  push:
+    branches: [ sandbox ]
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: Set up remotes to Client Test Repo
+      run: |
+        git remote add testing https://github.com/watchpartyappmain/watchparty-frontend-test.git
+        git fetch --all
+        git checkout -b sandbox-sync testing/master
+        git config --global user.email "watchpartyappmain@gmail.com"
+        git config --global user.name "watchpartyappmain"
+        git filter-branch --prune-empty --subdirectory-filter WatchParty/client sandbox
+        git merge -s ours sandbox --allow-unrelated-histories
+        git fetch --unshallow origin
+    - name: Push Client to Test Repo
+      env:
+        INPUT_GITHUB_TOKEN: ${{ secrets.personal_github_token }}
+        REPOSITORY: 'watchpartyappmain/watchparty-frontend-test'
+        INPUT_BRANCH: 'master'
+      run: |
+        remote_repo="https://watchpartymainapp:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+        git push "${remote_repo}" HEAD:${INPUT_BRANCH} --follow-tags --force;


### PR DESCRIPTION
This should move the test subfolders to their right subfolder, and deploy to their appropriate subfolders.

Check user watchpartyappmain to see where these repositories are.