### PR TITLE
Updated refs for remote & local

### DIFF
--- a/WatchParty/client/.github/workflows/deploy-test.yml
+++ b/WatchParty/client/.github/workflows/deploy-test.yml
@@ -30,6 +30,6 @@ jobs:
         env:
           HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
           HEROKU_APP_NAME: "watch-party-test-web-client"
-        run: 
+        run: |
           git fetch --all --unshallow
           git push https://heroku:${HEROKU_API_TOKEN}@git.heroku.com/${HEROKU_APP_NAME}.git HEAD:heroku-deploy

--- a/WatchParty/client/.github/workflows/deploy-test.yml
+++ b/WatchParty/client/.github/workflows/deploy-test.yml
@@ -30,4 +30,6 @@ jobs:
         env:
           HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
           HEROKU_APP_NAME: "watch-party-test-web-client"
-        run: git push https://heroku:${HEROKU_API_TOKEN}@git.heroku.com/${HEROKU_APP_NAME}.git HEAD:master
+        run: 
+          git fetch --all --unshallow
+          git push https://heroku:${HEROKU_API_TOKEN}@git.heroku.com/${HEROKU_APP_NAME}.git HEAD:heroku-deploy


### PR DESCRIPTION
Unshallowed remote ref, local ref now comes from deploy-heroku instead of master as wanted