### PR TITLE
wp-115-movie-page-support

### DIFF
--- a/WatchParty/client/src/components/MoviePage/MoviePage.css
+++ b/WatchParty/client/src/components/MoviePage/MoviePage.css
@@ -52,3 +52,86 @@
 .to-watch-btn{
    margin-left: 10px;
 }
+
+
+@media all and (max-width: 500px){
+
+    .info-container {
+        margin: auto;
+        width : 95%;
+        margin-top: 5px;
+        display: flex;
+        height: min-content;
+    }
+    
+    .img{
+        width: 10px;
+        height: min-content; 
+    }
+
+    .poster-container{
+        width: min-content;
+        height: min-content;
+        border: 1px solid black;
+        margin-top: 2%;
+    }
+    
+    .movie-details-container{
+        width: 100%;
+        height: auto;
+        margin-left: 5px;
+        padding-left: 5px;
+    }
+    
+    .title-section{
+        width: 100%;
+        height: min-content;
+        font-size: 150%;
+    }
+    
+    .overview {
+        width: 100%;
+        font-size: medium;
+        margin-top: 2px;
+        font-style: italic;
+    }
+    
+    .description{
+        margin-top: 0px;
+        width: 90%;
+        height: 30%;
+        overflow: scroll;
+        border: 1px solid grey;
+    }
+    
+    .btn-container{
+        margin-top: 10px;
+        width: 100%;
+        height: fit-content;
+        display: flex;
+    }
+    
+    .trailer-btn{
+        margin-top: 10px;
+        margin-left: 5px;
+        height: fit-content;
+    }
+    
+    .to-watch-btn{
+       margin-top: 10px;
+       margin-left:5px;
+       height: fit-content;
+       width: fit-content;
+    }
+    
+    .read-more-btn{
+        margin-top: 10px;
+        margin-left: -30px;
+        height: fit-content;
+    }
+    
+    .posters{
+        width: 100px;
+        height: 150px;
+    }
+}

--- a/WatchParty/client/src/components/MoviePage/MoviePage.css
+++ b/WatchParty/client/src/components/MoviePage/MoviePage.css
@@ -53,7 +53,6 @@
    margin-left: 10px;
 }
 
-
 @media all and (max-width: 500px){
 
     .info-container {

--- a/WatchParty/client/src/components/MoviePage/MoviePage.jsx
+++ b/WatchParty/client/src/components/MoviePage/MoviePage.jsx
@@ -53,17 +53,6 @@ class MoviePage extends React.Component {
     return (
       <div className="info-container">
         <div className="poster-container">
-<<<<<<< Updated upstream
-          <img
-            data-testid="poster-img"
-            onError={(event) => { event.target.src = "/default.png"; }} // eslint-disable-line no-param-reassign
-            src={`https://image.tmdb.org/t/p/w1280${movieItem.poster_path}`}
-            width="260px"
-            height="380px"
-            alt="movie poster"
-          />
-=======
-          
             <img
               className = "posters"
               data-testid="poster-img"
@@ -71,10 +60,8 @@ class MoviePage extends React.Component {
               src={`https://image.tmdb.org/t/p/w1280${movieItem.poster_path}`}
               width="260px"
               height="380px"
-              
               alt="movie poster"
             />
->>>>>>> Stashed changes
         </div>
         <div className="movie-details-container">
           <div className="title-section">

--- a/WatchParty/client/src/components/MoviePage/MoviePage.jsx
+++ b/WatchParty/client/src/components/MoviePage/MoviePage.jsx
@@ -53,7 +53,7 @@ class MoviePage extends React.Component {
     return (
       <div className="info-container">
         <div className="poster-container">
-            <img
+          <img
             className="posters"
             data-testid="poster-img"
             onError={this.defaultPoster}
@@ -61,7 +61,7 @@ class MoviePage extends React.Component {
             width="260px"
             height="380px"
             alt="movie poster"
-            />
+          />
         </div>
         <div className="movie-details-container">
           <div className="title-section">

--- a/WatchParty/client/src/components/MoviePage/MoviePage.jsx
+++ b/WatchParty/client/src/components/MoviePage/MoviePage.jsx
@@ -54,13 +54,13 @@ class MoviePage extends React.Component {
       <div className="info-container">
         <div className="poster-container">
             <img
-              className = "posters"
-              data-testid="poster-img"
-              onError={this.defaultPoster}
-              src={`https://image.tmdb.org/t/p/w1280${movieItem.poster_path}`}
-              width="260px"
-              height="380px"
-              alt="movie poster"
+            className="posters"
+            data-testid="poster-img"
+            onError={this.defaultPoster}
+            src={`https://image.tmdb.org/t/p/w1280${movieItem.poster_path}`}
+            width="260px"
+            height="380px"
+            alt="movie poster"
             />
         </div>
         <div className="movie-details-container">

--- a/WatchParty/client/src/components/MoviePage/MoviePage.jsx
+++ b/WatchParty/client/src/components/MoviePage/MoviePage.jsx
@@ -53,6 +53,7 @@ class MoviePage extends React.Component {
     return (
       <div className="info-container">
         <div className="poster-container">
+<<<<<<< Updated upstream
           <img
             data-testid="poster-img"
             onError={(event) => { event.target.src = "/default.png"; }} // eslint-disable-line no-param-reassign
@@ -61,6 +62,19 @@ class MoviePage extends React.Component {
             height="380px"
             alt="movie poster"
           />
+=======
+          
+            <img
+              className = "posters"
+              data-testid="poster-img"
+              onError={this.defaultPoster}
+              src={`https://image.tmdb.org/t/p/w1280${movieItem.poster_path}`}
+              width="260px"
+              height="380px"
+              
+              alt="movie poster"
+            />
+>>>>>>> Stashed changes
         </div>
         <div className="movie-details-container">
           <div className="title-section">


### PR DESCRIPTION
Added support in movie pages for 500px resolutions. 
<img width="281" alt="Screen Shot 2020-05-12 at 5 36 01 AM" src="https://user-images.githubusercontent.com/18234412/81668368-964a5f00-9412-11ea-801f-287faeb7f523.png">
